### PR TITLE
Quix-73479: Storage Access Gateway documentation

### DIFF
--- a/docs/quix-cloud/quix-lake/blob-storage.md
+++ b/docs/quix-cloud/quix-lake/blob-storage.md
@@ -14,6 +14,8 @@ Connect your cluster to a bucket/container so Quix can enable **[Quix Lake](./ov
     You can configure different connections for different clusters.
     Both the [Data Lake Sink](./data-lake/sink.md) and the [Lakehouse Sink](./lakehouse/sink.md) use this same connection.
 
+    One shared connection doesn't mean one shared view of the data: each team only sees its own data, and the bucket's keys stay locked away. See the [Storage Access Gateway](./secure-storage-access.md).
+
 ???+ info "Quix Lake at a glance"
     Quix Lake is the persistence layer of Quix Cloud. It ships in two flavors that share this blob storage connection:
 

--- a/docs/quix-cloud/quix-lake/data-lake/api.md
+++ b/docs/quix-cloud/quix-lake/data-lake/api.md
@@ -204,4 +204,4 @@ Removes only the listed property names.
 ## Security
 
 * Authenticate with **Bearer** JWT.
-* Authorization is enforced per workspace.
+* Authorization is enforced per workspace; a token only reaches the workspaces it belongs to. See the [Storage Access Gateway](../secure-storage-access.md).

--- a/docs/quix-cloud/quix-lake/data-lake/overview.md
+++ b/docs/quix-cloud/quix-lake/data-lake/overview.md
@@ -58,7 +58,7 @@ See **[Open format](./open-format.md)** for the full layout and schemas.
 ## Operational behavior
 
 * **Soft deletion** — catalog deletions move items to Trash for a short retention window before permanent removal, with restore and delete-forever actions.
-* **Security** — you control IAM, keys, encryption, retention, and audit in your own cloud account.
+* **Security** — you control IAM, keys, encryption, retention, and audit in your own cloud account. Within Quix, each team only sees its own data by default. See the [Storage Access Gateway](../secure-storage-access.md).
 
 ## See also
 
@@ -68,3 +68,4 @@ See **[Open format](./open-format.md)** for the full layout and schemas.
 * [Data Lake API](./api.md) — programmatic search, metadata, deletion
 * [Replay](./replay.md) — push persisted datasets back into Kafka
 * [Blob storage connections](../blob-storage.md) — connect your bucket or container
+* [Storage Access Gateway](../secure-storage-access.md): how private-by-default, per-team access works

--- a/docs/quix-cloud/quix-lake/secure-storage-access.md
+++ b/docs/quix-cloud/quix-lake/secure-storage-access.md
@@ -1,0 +1,79 @@
+---
+title: Storage Access Gateway
+description: How Quix keeps your lake data private by default, with each team seeing only its own data even though the whole organization shares one storage bucket.
+---
+
+# Storage Access Gateway
+
+Every cluster connects to a single storage bucket for [Quix Lake](./overview.md), and that bucket is shared across your whole organization. The **Storage Access Gateway** controls who can see and change what inside it, so each team only works with the data it is meant to.
+
+It sits between the platform and your storage and checks every request. It confirms who is asking and which data they are allowed to reach, then lets through only what they are permitted to see.
+
+!!! info "Nothing to set up"
+    The gateway is active automatically once a [blob storage connection](./blob-storage.md) exists for the cluster. There are no keys to manage and no settings to configure.
+
+## Two kinds of folders
+
+How a folder behaves by default depends on its kind. You can see and change this in the **Storage permissions** panel, where every folder shows its current visibility.
+
+**Environment folders.** Each environment keeps its lake data in its own folder, shown with a people icon. Its default visibility is **User Permissions**: members get the same read and write access they have in that environment. If you can view the environment you can read its data, and if you can edit the environment you can write to it. Other teams cannot see it unless it is shared.
+
+**Other folders.** Any folder that is not tied to an environment, such as one you create yourself in the bucket, is shown with a lock icon. Its default visibility is **Private**: no one in the organization can access it, only organization administrators. It becomes available to others only when someone shares it.
+
+## What it does
+
+**Keeps each team's data to itself.** The data an environment writes is visible only to that environment's members. Other teams in the organization cannot see it.
+
+**Keeps storage keys protected.** The credentials for your bucket stay inside the gateway and are never handed to the rest of the platform.
+
+**Leaves your data in place.** The gateway only governs access. Your files stay in your own cloud storage, untouched.
+
+## Folder visibility
+
+You set a folder's visibility from the menu on its row in the **Storage permissions** panel. Opening a folder past its default is called *sharing*, and there are two sharing levels: **Anyone can read** and **Anyone can read & write**. A folder's setting applies to everything beneath it, unless a deeper folder overrides it.
+
+| Visibility | What it means | Default for |
+|---|---|---|
+| **User Permissions** | Members get the same read and write access they have in that environment | Environment folders |
+| **Private** | No one in your organization can access it (administrators only) | Other folders |
+| **Anyone can read** | Everyone in your organization can read it | Opt-in |
+| **Anyone can read & write** | Everyone in your organization can read and change it | Opt-in |
+
+!!! note "Sharing stays within your organization"
+    Sharing only ever opens a folder to people signed in to your Quix organization. It is never exposed to the public internet.
+
+## Who can read and write
+
+For an environment folder, what you can do follows your access to that environment:
+
+| Your access to the environment | What you can do with its data |
+|---|---|
+| **Can view** | Browse, search, query, and replay |
+| **Can edit** | The above, plus write and delete |
+| **No access** | The data is not shown to you, unless it has been shared |
+
+The same rules apply to anything acting on your behalf:
+
+* A **dev session** uses your permissions. It can reach exactly what you can.
+* A **deployed application** works on behalf of its own environment. It can read its own data and anything shared across the organization, and write to its own environment and anywhere shared for editing. It cannot reach another team's private data.
+
+## Where it applies
+
+You work with the lake exactly as before. The gateway only determines what appears:
+
+* **[Data Lake](./data-lake/user-interface.md):** when you browse, you only see the environments and folders you are allowed to see.
+* **[Lakehouse](./lakehouse/overview.md):** SQL queries return results only from environments you belong to or that have been shared with you.
+* **[Blob storage](./blob-storage.md):** the bucket is still connected once per cluster, and access to its contents is now governed per folder.
+
+## Examples
+
+**Two environments.** An analytics team and an operations team work in separate environments in the same organization. By default, each team sees only its own environment's data, and neither can see the other's when browsing the lake. If the analytics team sets a folder of reference data to **Anyone can read**, every team can then read it, but no one else can change it.
+
+**A shared working folder.** Someone creates a folder in the bucket that is not tied to any environment. While it stays **Private**, only administrators can reach it. Set it to **Anyone can read & write**, and anyone in the organization can read and write to it.
+
+## See also
+
+* [Quix Lake overview](./overview.md): how the Data Lake and Lakehouse fit together
+* [Blob storage connections](./blob-storage.md): connect the bucket this sits in front of
+* [Data Lake user interface](./data-lake/user-interface.md): browse your datasets
+* [Lakehouse](./lakehouse/overview.md): run SQL over your data

--- a/docs/quix-cloud/quix-lake/secure-storage-access.md
+++ b/docs/quix-cloud/quix-lake/secure-storage-access.md
@@ -44,13 +44,13 @@ You set a folder's visibility from the menu on its row in the **Storage permissi
 
 ## Who can read and write
 
-You get the same access to an environment's data as you already have to the environment itself:
+Your access to the data is the same as your access to the environment:
 
-| Your access to the environment | What you can do with its data |
+| What you can do in the environment | What you can do with its data |
 |---|---|
-| **Can view** | Read it |
-| **Can edit** | Read it and change it |
-| **No access** | Nothing, unless the data has been shared |
+| **View** it | **Read** it |
+| **Edit** it | **Read and change** it |
+| **Nothing** | **Nothing**, unless it has been shared |
 
 The same applies to things acting on your behalf:
 

--- a/docs/quix-cloud/quix-lake/secure-storage-access.md
+++ b/docs/quix-cloud/quix-lake/secure-storage-access.md
@@ -44,18 +44,18 @@ You set a folder's visibility from the menu on its row in the **Storage permissi
 
 ## Who can read and write
 
-For an environment folder, what you can do follows your access to that environment:
+You get the same access to an environment's data as you already have to the environment itself:
 
 | Your access to the environment | What you can do with its data |
 |---|---|
-| **Can view** | Browse, search, query, and replay |
-| **Can edit** | The above, plus write and delete |
-| **No access** | The data is not shown to you, unless it has been shared |
+| **Can view** | Read it |
+| **Can edit** | Read it and change it |
+| **No access** | Nothing, unless the data has been shared |
 
-The same rules apply to anything acting on your behalf:
+The same applies to things acting on your behalf:
 
-* A **dev session** uses your permissions. It can reach exactly what you can.
-* A **deployed application** works on behalf of its own environment. It can read its own data and anything shared across the organization, and write to its own environment and anywhere shared for editing. It cannot reach another team's private data.
+* A **dev session** can do exactly what you can.
+* A **deployed application** acts as its own environment: it can read its own data and anything shared, and change its own data. It cannot see another team's private data.
 
 ## Where it applies
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,10 +91,11 @@ nav:
     - 'Quix Lake':
       - 'Overview': 'quix-cloud/quix-lake/overview.md'
       - 'Blob storage': 'quix-cloud/quix-lake/blob-storage.md'
+      - 'Storage Access Gateway': 'quix-cloud/quix-lake/secure-storage-access.md'
       - 'Data Lake':
         - 'Overview': 'quix-cloud/quix-lake/data-lake/overview.md'
         - 'Open format': 'quix-cloud/quix-lake/data-lake/open-format.md'
-        - 'Sink': 'quix-cloud/quix-lake/data-lake/sink.md'
+        - 'Data Lake Sink': 'quix-cloud/quix-lake/data-lake/sink.md'
         - 'User interface': 'quix-cloud/quix-lake/data-lake/user-interface.md'
         - 'API': 'quix-cloud/quix-lake/data-lake/api.md'
         - 'Replay':
@@ -102,7 +103,7 @@ nav:
           - 'Message transformations': 'quix-cloud/quix-lake/data-lake/replay-transformations.md'
       - 'Lakehouse':
         - 'Overview': 'quix-cloud/quix-lake/lakehouse/overview.md'
-        - 'Sink': 'quix-cloud/quix-lake/lakehouse/sink.md'
+        - 'Lakehouse Sink': 'quix-cloud/quix-lake/lakehouse/sink.md'
         - 'Query': 'quix-cloud/quix-lake/lakehouse/query.md'
         - 'Catalog': 'quix-cloud/quix-lake/lakehouse/catalog.md'
         - 'UI': 'quix-cloud/quix-lake/lakehouse/ui.md'


### PR DESCRIPTION
Adds a user-facing documentation page for the Storage Access Gateway under Quix Lake, written for people using Quix Cloud rather than the engineers building it. The page explains that the whole organization shares one storage bucket and the gateway is what keeps each team seeing only its own data, then walks through the two kinds of folders: environment folders, which default to User Permissions so members get the same read and write access they have in the environment, and other folders, which default to Private. It covers the four visibility settings, how a folder's setting is inherited by everything beneath it, and how the same rules show up when you browse the Data Lake, run Lakehouse SQL, or work through blob storage.

The content was checked against the shipping behaviour in the sc-73407 branches (SAG, portal-api, datalake-api and lakehouse-query), so the wording matches what is actually enforced rather than the older model, and it uses the real labels from the Storage permissions UI. It also adds the nav entry and a few cross-references from the blob storage and Data Lake pages.

One small extra while I was in the nav: the two "Sink" entries under Managed services were indistinguishable, so they now read "Data Lake Sink" and "Lakehouse Sink". Because both menu spots point at the same page, MkDocs uses one label for both, so the same names now also appear under the Data Lake and Lakehouse submenus.
