### PR TITLE
Quix-73484: Add descriptor v2.0 (YAML 2.0) documentation page

### DIFF
--- a/docs/quix-cloud/applications/shared-folders.md
+++ b/docs/quix-cloud/applications/shared-folders.md
@@ -7,7 +7,7 @@ description: Manage and include shared folders in your Quix application.
 
 ## Before we start
 
-Complete the [previous steps](./create-application.md) or the [CLI Quickstart](../quix-cli/cli-quickstart.md) to ensure you can edit code both locally and in Quix Cloud.
+Complete the [previous steps](./create-application.md) or the [CLI Quickstart](../../quix-cli/cli-quickstart.md) to ensure you can edit code both locally and in Quix Cloud.
 
 ## Why use Shared Folders
 
@@ -70,7 +70,7 @@ includedFolders:
 
    ![The selected folders will now appear in the online IDE](../../images/shared-folders/result.png){: style="max-width:500px"}
 
-Whenever you [deploy your application](../deployments/overview.md), run it in the online IDE, or execute it [locally using the CLI](../quix-cli/local-development/local-debug.md), all directories listed under `includedFolders` will be bundled with your application to ensure they are available at runtime.
+Whenever you [deploy your application](../deployments/overview.md), run it in the online IDE, or execute it [locally using the CLI](../../quix-cli/local-development/local-debug.md), all directories listed under `includedFolders` will be bundled with your application to ensure they are available at runtime.
 
 !!! warning
-    Make sure your Dockerfile is up-to-date if you’re updating an existing application. Refer to the [dockerfile reference](../quix-cli/yaml-reference/dockerfile.md) for details.
+    Make sure your Dockerfile is up-to-date if you’re updating an existing application. Refer to the [dockerfile reference](../../quix-cli/yaml-reference/dockerfile.md) for details.

--- a/docs/quix-cloud/deployments/deploy-external-image.md
+++ b/docs/quix-cloud/deployments/deploy-external-image.md
@@ -46,19 +46,20 @@ The deployment settings for external images are similar to application deploymen
 
 ## Working on the Command Line
 
-To deploy an external image from the command line, modify your [`quix.yaml`](../quix-cli/yaml-reference/pipeline-descriptor.md) file to include the image. 
+To deploy an external image from the command line, modify your [`quix.yaml`](../../quix-cli/yaml-reference/pipeline-descriptor.md) file to include the image. 
 
 Example:
 
 ```yaml
 - name: custom-service
-    image: my-registry.com/my-service:1.2.3
-    deploymentType: Service
-    resources:
+  image: my-registry.com/my-service:1.2.3
+  deploymentType: Service
+  resources:
+    limits:
       cpu: 300
       memory: 600
-      replicas: 2
-    desiredStatus: Running
+    replicas: 2
+  desiredStatus: Running
 ```
 
 Then use the following commands:
@@ -66,7 +67,7 @@ Then use the following commands:
 - **Sync local changes**: Use the `quix local pipeline sync --update` command. This updates your pipeline in Quix Cloud based on your `quix.yaml` file.
 - **Sync remote environment**: Use the `quix envs sync` command to synchronize an environment with its project repository.
 
-For more details on CLI usage, see the [CLI documentation](../quix-cli/overview.md).
+For more details on CLI usage, see the [CLI documentation](../../quix-cli/overview.md).
 
 ## Private Container Registries
 

--- a/docs/quix-cloud/deployments/global-variables.md
+++ b/docs/quix-cloud/deployments/global-variables.md
@@ -268,7 +268,7 @@ variables:
 
     The nested `variables:` list belongs to the **application** definition. A deployment in `quix.yaml` only ever references the group by `variableGroupId` — it never lists the group's nested variables. At deploy time the actual values come from the value set assigned to the environment, not from this schema.
 
-See [Project structure](../projects/project-structure.md) for how `app.yaml` and `quix.yaml` relate.
+See [YAML 1.0 and 2.0](../projects/yaml-2-0.md) for how a deployment inherits these declarations from `app.yaml`.
 
 ## Access the values from your code
 
@@ -388,10 +388,9 @@ deployments:
     # input, redis and payments are inherited from app.yaml (see note below)
 ```
 
-<!-- TODO(SC-73484): point this collapsible at the YAML 2.0 inheritance docs once that page exists. -->
 ??? info "Where are `input`, `redis` and `payments`?"
 
-    The deployment references the `order-processor` application, so under descriptor **version 2.0** it **inherits** the variables declared in that application's `app.yaml` — they aren't repeated here. Each environment's actual values come from the variable group's assigned value set, not from `quix.yaml`.
+    The deployment references the `order-processor` application, so under descriptor **version 2.0** it **inherits** the variables declared in that application's `app.yaml` — they aren't repeated here. Each environment's actual values come from the variable group's assigned value set, not from `quix.yaml`. See [YAML 1.0 and 2.0](../projects/yaml-2-0.md) for the full inheritance and resolution model, including the resolved deployment the platform computes.
 
 In this example:
 

--- a/docs/quix-cloud/deployments/project-variables.md
+++ b/docs/quix-cloud/deployments/project-variables.md
@@ -373,7 +373,7 @@ variables:
 
 Every other deployment keeps inheriting `info`, and `LOG_LEVEL` stays absent from their blocks.
 
-Inheritance applies to deployments that reference an `application` + `version`; managed services don't inherit. See [Project structure](../projects/project-structure.md) for how the two files relate.
+Inheritance applies to deployments that reference an `application` + `version`; managed services don't inherit. See [YAML 1.0 and 2.0](../projects/yaml-2-0.md) for the full inheritance and resolution model, including what the platform stores versus what it computes.
 
 ## Full example
 

--- a/docs/quix-cloud/projects/project-structure.md
+++ b/docs/quix-cloud/projects/project-structure.md
@@ -2,7 +2,7 @@
 
 This page looks at the file structure of a typical project in Quix, as hosted in its Git repository. 
 
-A project in Quix maps to a Git repository. Within a project you can create multiple environments, and these correspond to branches in the Git repository. Within a branch (environment) there are some root files. One example of this is `quix.yaml` which defines the pipeline, and then each application in the pipeline has its own folder, containing code and configuration, such as the `main.py` and `app.yaml` files.
+A project in Quix maps to a Git repository. Within a project you can create multiple environments, and these correspond to branches in the Git repository. Within a branch (environment) there are some root files. The most important is `quix.yaml`, the **pipeline descriptor** that defines the pipeline. Each application in the pipeline also has its own folder, containing its code and its **application descriptor**, `app.yaml`, alongside files such as `main.py`. Both descriptors matter. The `app.yaml` configures the whole application — its language, Dockerfile, entry point, and the **default values for its variables**. From descriptor [version 2.0](./yaml-2-0.md), each `quix.yaml` deployment **inherits those variable defaults** and declares a variable only to **override** it for that deployment, rather than repeating them all.
 
 ## Pipeline
 
@@ -14,16 +14,16 @@ Looking at the project stored in Git, it would have the following structure:
 
 ![Project structure](../../images/project-structure/project-structure.png)
 
-Note the `quix.yaml` file that defines the entire pipeline. There is aso a folder for the application, `Demo Data`.
+Note the `quix.yaml` file that defines the pipeline, and the `Demo Data` folder for the application, which holds its own `app.yaml`. Under descriptor version 2.0 the two work together: each `app.yaml` defines its application's defaults — its variables' default values, plus build and runtime settings — and `quix.yaml` assembles the deployments, inheriting those defaults and overriding a variable only where a deployment needs a different value.
 
-The complete `quix.yaml` file is shown here:
+The complete `quix.yaml` file is shown here, using descriptor **version 2.0**:
 
 ``` yaml
 # Quix Project Descriptor
 # This file describes the data pipeline and configuration of resources of a Quix Project.
 
 metadata:
-  version: 1.0
+  version: 2.0
 
 # This section describes the Deployments of the data pipeline
 deployments:
@@ -32,16 +32,11 @@ deployments:
     deploymentType: Job
     version: ada522b5199fc9667505b4dd19980995804ca764
     resources:
-      cpu: 200
-      memory: 200
+      limits:
+        cpu: 200
+        memory: 200
       replicas: 1
     libraryItemId: 7abe02e1-1e75-4783-864c-46b930b42afe
-    variables:
-      - name: Topic
-        inputType: OutputTopic
-        description: Name of the output topic to write into
-        required: true
-        value: f1-data
 
 # This section describes the Topics of the data pipeline
 topics:
@@ -54,7 +49,7 @@ topics:
       retentionInBytes: 262144000
 ```
 
-This defines one or more deployments, and their allocated resources, as well as other information such as the code commit version to use, in this case `ada522b`. The topics in the pipeline are also defined here.
+This defines one or more deployments and their allocated resources, along with other information such as the code commit version to use, here `ada522b`. The topics in the pipeline are also defined here. Note there is **no `variables:` block** on the deployment: under version 2.0 the deployment inherits its variables — such as the `Topic` output — from the application's `app.yaml`, so they are not repeated in `quix.yaml`. See [YAML 1.0 and 2.0](./yaml-2-0.md) for how inheritance works and how the versions differ.
 
 ## Application
 
@@ -95,7 +90,32 @@ variables:
         value: file
 ```
 
-Each option has a `label` (shown in the UI dropdown) and a `value` (the actual value set in the environment variable). Other available input types include `FreeText`, `Secret`, `InputTopic`, and `OutputTopic`.
+Each option has a `label` (shown in the UI dropdown) and a `value` (the actual value set in the environment variable).
+
+The available input types are:
+
+| Input type | Use |
+|---|---|
+| `FreeText` | A plain text value. |
+| `HiddenText` | A plain text value masked in the UI (not a managed secret). |
+| `InputTopic` / `OutputTopic` | A topic the application reads from / writes to. |
+| `Options` | A selection from a predefined `label`/`value` list (the list lives in `app.yaml`). |
+| `ProjectVariable` | A value looked up from the project's variables store; set `secret: true` for sensitive values such as API keys. |
+| `VariableGroup` | A reference to an organization-level [variable group](../deployments/global-variables.md). |
+
+To store a secret such as an API key, use a `ProjectVariable` with `secret: true` — the modern replacement for the older `Secret` input type:
+
+``` yaml
+variables:
+  - name: API_KEY
+    inputType: ProjectVariable
+    description: Third-party API key
+    secret: true
+    defaultValue: THIRD_PARTY_API_KEY
+    required: true
+```
+
+See [Project variables](../deployments/project-variables.md) for how project variables resolve per environment.
 
 This provides a reference to the Dockerfile that is to be used to build the application before it is deployed. This is located in the `build` directory, and the full Dockerfile for this application is shown here:
 

--- a/docs/quix-cloud/projects/yaml-2-0.md
+++ b/docs/quix-cloud/projects/yaml-2-0.md
@@ -1,0 +1,274 @@
+# YAML 1.0 and 2.0
+
+Every Quix project is described by two kinds of YAML file: one **pipeline descriptor**, `quix.yaml`, at the root of the project, and one **application descriptor**, `app.yaml`, in each application folder. The `metadata.version` field at the top of `quix.yaml` selects the descriptor version.
+
+From **version 2.0** — informally "YAML 2.0" — a deployment **inherits** its variables from the application's `app.yaml` instead of repeating them in `quix.yaml`. Version 1.0 has no inheritance: every deployment carries the full definition of each variable.
+
+This page explains why version 2.0 exists, how inheritance works, the same deployment shown across versions (written and computed), and how to migrate. For how `quix.yaml` and `app.yaml` sit in the repository, see [Project structure](./project-structure.md).
+
+!!! tip "Always use version 2.0"
+
+    Version 2.0 is the current descriptor and unlocks the full capabilities of the platform, including variable inheritance. New projects use it by default. Set `metadata.version` to `2.0` in any project still on 1.0.
+
+## Why version 2.0
+
+Under **version 1.0**, every deployment in `quix.yaml` repeats the complete definition of each variable — its `inputType`, `description`, `required` flag, and value. The same description and the same properties are duplicated in `app.yaml`, in `quix.yaml`, and across each deployment of the same application. Changing one detail of an application means editing it in several places.
+
+**Version 2.0** removes that duplication:
+
+* The application declares each variable **once**, in its `app.yaml`.
+* Each deployment of that application **inherits** the declaration. `quix.yaml` records only the properties a deployment overrides.
+* Editing the application — adding a variable, changing a description or a default — reaches every deployment of it the next time it is deployed, with no edit to `quix.yaml`.
+
+The result is a shorter, clearer `quix.yaml` that holds only what differs between deployments, and a single source of truth for each variable in `app.yaml`.
+
+## How inheritance works
+
+Inheritance resolves a deployment's variables from the application it references:
+
+* **`app.yaml` is the source of truth.** It declares each variable's `inputType`, `description`, `required` flag, and its value or key (the `defaultValue` field). The portal writes `app.yaml` for you when you add an application variable in the UI.
+* **A deployment inherits the whole set** when it references an application by both `application` and `version`. Properties left at the application default are omitted from `quix.yaml`.
+* **`quix.yaml` records only overrides.** A deployment lists a variable solely to change a property for that deployment. A deployment that overrides nothing has **no `variables:` block at all**.
+* **Override one property** by declaring just that variable with the changed field; the rest stays inherited.
+
+The same variable uses a different field name on each side:
+
+| Concept | `app.yaml` (declare once) | `quix.yaml` deployment (override only) |
+|---|---|---|
+| Plain value | `defaultValue: orders` | `value: orders` |
+| Project-variable key | `defaultValue: THIRD_PARTY_API_KEY` | `variableKey: THIRD_PARTY_API_KEY` |
+| Variable-group reference | `variableGroupId: redis-config` | `variableGroupId: redis-config` |
+| Secret flag | `secret: true` | `secret: true` |
+
+Inheritance applies only when:
+
+* `metadata.version` is **2.0 or higher**. Under 1.0 nothing is inherited.
+* The deployment references both an `application` and a `version`. A deployment that omits either — such as one built from a raw `image` — or a **managed** deployment, does not inherit.
+
+Variable names are matched **case-insensitively** between `quix.yaml` and `app.yaml`.
+
+## The same deployment across versions
+
+One application, shown four ways: the `app.yaml` that declares the variables, then a single deployment of it written as **version 1.0**, written as **version 2.0**, and the **version 2.0 file the platform computes** at deploy time.
+
+### The application: `app.yaml`
+
+The `order-processor` application declares an input topic, a project variable, and two [variable groups](../deployments/global-variables.md). A group carries its full definition in `app.yaml` — its identifier, names, and the **nested `variables:`** that make up the group:
+
+```yaml
+# app.yaml — declares the application's variables once
+name: order-processor
+language: python
+variables:
+  - name: input
+    inputType: InputTopic
+    required: true
+    defaultValue: orders
+  - name: API_KEY
+    inputType: ProjectVariable
+    description: Third-party API key
+    required: true
+    defaultValue: THIRD_PARTY_API_KEY
+    secret: true
+  - name: redis
+    inputType: VariableGroup
+    required: true
+    variableGroupId: redis-config
+    variableGroupName: Redis config
+    variableGroupDescription: Shared Redis connection
+    variables:                          # the group's variables
+      - key: REDIS_HOST
+        description: Redis server hostname
+        defaultValue: localhost
+        required: true
+      - key: REDIS_PORT
+        description: Redis server port
+        defaultValue: "6379"
+        required: true
+      - key: REDIS_PASSWORD
+        description: Redis auth password
+        secret: true
+        required: true
+  - name: payments
+    inputType: VariableGroup
+    required: true
+    variableGroupId: payment-provider
+    variableGroupName: Payment provider
+    variableGroupDescription: Payment provider credentials
+    variables:                          # the group's variables
+      - key: PAYMENT_API_KEY
+        description: Payment provider API key
+        secret: true
+        required: true
+      - key: PAYMENT_API_URL
+        description: Payment provider base URL
+        defaultValue: https://api.payments.example
+        required: true
+dockerfile: build/dockerfile
+runEntryPoint: main.py
+```
+
+A deployment references the group, not its members — the nested `variables:` list never appears in `quix.yaml`. At deploy time the group's actual values come from the [value set](../deployments/global-variables.md) assigned to the environment.
+
+### Version 1.0: every variable written out
+
+Under 1.0 the deployment carries the full definition of each variable itself, duplicating what `app.yaml` already declares:
+
+```yaml
+# quix.yaml — version 1.0
+metadata:
+  version: 1.0
+
+deployments:
+  - name: Order processor
+    application: order-processor
+    version: latest
+    deploymentType: Service
+    resources:
+      limits:
+        cpu: 200
+        memory: 500
+      replicas: 1
+    variables:
+      - name: input
+        inputType: InputTopic
+        required: true
+        value: orders
+      - name: API_KEY
+        inputType: ProjectVariable
+        description: Third-party API key
+        required: true
+        variableKey: THIRD_PARTY_API_KEY
+        secret: true
+      - name: redis
+        inputType: VariableGroup
+        required: true
+        variableGroupId: redis-config
+        variableGroupName: Redis config
+        variableGroupDescription: Shared Redis connection
+      - name: payments
+        inputType: VariableGroup
+        required: true
+        variableGroupId: payment-provider
+        variableGroupName: Payment provider
+        variableGroupDescription: Payment provider credentials
+```
+
+### Version 2.0: what you write
+
+The deployment inherits every variable from the application, so the file you keep in Git holds only the pipeline fields — no `variables:` block at all:
+
+```yaml
+# quix.yaml — version 2.0, the written form
+metadata:
+  version: 2.0
+
+deployments:
+  - name: Order processor
+    application: order-processor
+    version: latest
+    deploymentType: Service
+    resources:
+      limits:
+        cpu: 200
+        memory: 500
+      replicas: 1
+```
+
+### Version 2.0: what the platform computes
+
+When the platform reads the descriptor to deploy, it expands the minimal file by inheriting the application's variables. This resolved form is **virtual** — computed in memory at deploy time and never written to Git:
+
+```yaml
+# quix.yaml — version 2.0, the computed (virtual) form
+metadata:
+  version: 2.0
+
+deployments:
+  - name: Order processor
+    application: order-processor
+    version: latest
+    deploymentType: Service
+    resources:
+      limits:
+        cpu: 200
+        memory: 500
+      replicas: 1
+    variables:
+      - name: input
+        inputType: InputTopic
+        required: true
+        value: orders
+      - name: API_KEY
+        inputType: ProjectVariable
+        description: Third-party API key
+        required: true
+        variableKey: THIRD_PARTY_API_KEY
+        secret: true
+      - name: redis
+        inputType: VariableGroup
+        required: true
+        variableGroupId: redis-config
+        variableGroupName: Redis config
+        variableGroupDescription: Shared Redis connection
+      - name: payments
+        inputType: VariableGroup
+        required: true
+        variableGroupId: payment-provider
+        variableGroupName: Payment provider
+        variableGroupDescription: Payment provider credentials
+```
+
+This computed form is identical to the version 1.0 file above, apart from `metadata.version`: version 2.0 produces the same result from a far smaller file. The `input` value and the `API_KEY` project-variable key (`variableKey`) are materialized from the application defaults; the `redis` and `payments` references are materialized as references only — the group's member variables (`REDIS_HOST`, `PAYMENT_API_KEY`, and so on) are not inlined, since their values resolve from the environment's value set at deploy time.
+
+### Override a single deployment
+
+To run one deployment differently — a different input topic, say — declare just the changed variable on that deployment. Everything else stays inherited:
+
+```yaml
+# quix.yaml — override the input topic for one deployment
+deployments:
+  - name: Order processor
+    application: order-processor
+    version: latest
+    deploymentType: Service
+    variables:
+      - name: input
+        value: priority-orders
+```
+
+Every other property of `input`, and every other variable, is still inherited from `app.yaml`.
+
+## Migrate from 1.0 to 2.0
+
+Moving a project to version 2.0 takes two steps:
+
+1. **Confirm `app.yaml` declares the variables.** Each application's variables must exist in its `app.yaml`, since that is what deployments inherit from. The portal writes them there when you add an application variable in the UI.
+2. **Set the descriptor version.** Change `metadata.version` to `2.0`. Inheritance takes effect immediately — from this point the platform resolves each deployment's variables from its application.
+
+The stored `quix.yaml` is **not** rewritten the moment you switch to 2.0. Minimizing the file is **eventually consistent**: the next time you change anything the descriptor covers — a deployment, a variable, resources, a topic — through the UI or the API, the platform saves the file in its migrated, minimal form, stripping every property that matches an application default. Until that next change, `quix.yaml` keeps its existing entries; they still resolve correctly, because inheritance happens when the descriptor is read regardless of how the file is written.
+
+What to expect:
+
+* **No immediate rewrite.** The version change alone neither minimizes the file nor redeploys anything.
+* **Migration on the next save.** The first operation that persists the descriptor writes the minimal form.
+* **Unchanged runtime behavior.** The resolved variables a deployment receives are the same before and after migration — they always come from `app.yaml` defaults, project variables, and variable-group value sets.
+
+## Reference
+
+This section specifies the resolution rules precisely, for power users and for tooling or AI assistants that generate the YAML.
+
+* **Version gate.** Inheritance and default-stripping apply only when `metadata.version` is `2.0` or higher. A 1.0 descriptor, or a deployment whose version cannot be read, is left exactly as written.
+* **Eligible deployments.** A deployment inherits only when it sets both `application` and `version` and its `deploymentType` is not `Managed`. A deployment that omits either field — including one built from a raw `image` — and managed deployments are skipped.
+* **Matching.** A `quix.yaml` variable is matched to an `app.yaml` variable by `name`, case-insensitively.
+* **Property precedence.** A property set explicitly in `quix.yaml` wins. A property left unset is inherited from the matching `app.yaml` variable. Applicable properties are `inputType`, `description`, `required`, `multiline`, the value or key (`value` / `variableKey`, or legacy `secretKey`), the variable-group fields (`variableGroupId`, `variableGroupName`, `variableGroupDescription`), and the `secret` flag.
+* **Materialized defaults.** Variables declared in `app.yaml` but omitted from a deployment are added to the computed descriptor at deploy time with their application defaults.
+* **Group members are not inlined.** A deployment carries a group's reference fields (`variableGroupId`, plus the inherited `variableGroupName` and `variableGroupDescription`), but never the group's **nested member variables** — those live in `app.yaml` and in the [variable group](../deployments/global-variables.md) definition. Their values resolve from the environment's assigned value set.
+* **Lazy write-back.** Switching to 2.0 does not rewrite `quix.yaml`. On the next descriptor save — any UI or API change that persists the file — each deployment property equal to the application default is stripped, keeping the stored file minimal.
+
+## Related pages
+
+* [Project structure](./project-structure.md) — how `quix.yaml` and `app.yaml` sit in the project repository.
+* [Project variables](../deployments/project-variables.md) — per-environment values and secrets a deployment inherits from its application.
+* [Global variables](../deployments/global-variables.md) — organization-wide variable groups referenced from `app.yaml`.
+* [Pipeline descriptor reference](../../quix-cli/yaml-reference/pipeline-descriptor.md) — the full field reference for `quix.yaml`.

--- a/docs/quix-cloud/quix-lake/data-lake/replay.md
+++ b/docs/quix-cloud/quix-lake/data-lake/replay.md
@@ -35,8 +35,9 @@ deployments:
     version: latest
     deploymentType: Managed
     resources:
-      cpu: 200
-      memory: 500
+      limits:
+        cpu: 200
+        memory: 500
       replicas: 1
     configuration:
       # Select data (source)

--- a/docs/quix-cloud/quix-lake/data-lake/sink.md
+++ b/docs/quix-cloud/quix-lake/data-lake/sink.md
@@ -98,8 +98,9 @@ deployments:
   version: latest
   deploymentType: Managed
   resources:
-    cpu: 500
-    memory: 1024
+    limits:
+      cpu: 500
+      memory: 1024
     replicas: 1
   configuration:
     # Source

--- a/docs/quix-cloud/quix-lake/lakehouse/sink.md
+++ b/docs/quix-cloud/quix-lake/lakehouse/sink.md
@@ -54,8 +54,9 @@ deployments:
     version: latest
     deploymentType: Managed
     resources:
-      cpu: 500
-      memory: 1024
+      limits:
+        cpu: 500
+        memory: 1024
       replicas: 1
     configuration:
       topic: telemetry

--- a/docs/quix-cloud/services/dynamic-configuration.md
+++ b/docs/quix-cloud/services/dynamic-configuration.md
@@ -28,8 +28,9 @@ deployments:
   version: latest
   deploymentType: Managed
   resources:
-    cpu: 200
-    memory: 500
+    limits:
+      cpu: 200
+      memory: 500
     replicas: 1
   configuration:
     # Kafka topic for configuration updates

--- a/docs/quix-cloud/services/overview.md
+++ b/docs/quix-cloud/services/overview.md
@@ -37,9 +37,10 @@ deployments:
   version: latest
   deploymentType: Managed
   resources:
-   cpu: 200
-   memory: 500
-   replicas: 1
+    limits:
+      cpu: 200
+      memory: 500
+    replicas: 1
   configuration:
    topic: config-updates
    mongoDatabase: quix

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,13 @@ nav:
         - 'Protected environments': 'quix-cloud/projects/protected-environment.md'
         - 'Syncing an environment': 'quix-cloud/projects/syncing-environment.md'
         - 'Testing environments': 'quix-cloud/projects/testing-environments.md'
-      - 'Project structure': 'quix-cloud/projects/project-structure.md'
+      - 'Project structure':
+        - 'Overview': 'quix-cloud/projects/project-structure.md'
+        - 'YAML 1.0 and 2.0': 'quix-cloud/projects/yaml-2-0.md'
+        - 'File Reference':
+          - 'Pipeline YAML (quix.yaml)': 'quix-cli/yaml-reference/pipeline-descriptor.md'
+          - 'Application YAML (app.yaml)': 'quix-cli/yaml-reference/app-descriptor.md'
+          - 'Docker Configuration (dockerfile)': 'quix-cli/yaml-reference/dockerfile.md'
       - 'Git submodules': 'quix-cloud/projects/submodules.md'
     - 'Applications':
       - 'Overview': 'quix-cloud/applications/overview.md'
@@ -347,7 +353,7 @@ nav:
         - Yugabytedb sink: quix-connectors/quix-streams/sinks/coming-soon/Yugabytedb-sink.md
 
 
-  - 'Quix CLI': '!import https://github.com/quixio/quix-cli/?branch=1.6.1-docs'
+  - 'Quix CLI': '!import https://github.com/quixio/quix-cli/?branch=1.6.2-docs'
   - 'Knowledge base':
     - 'Guides':
       - 'What is Quix?': 'kb/what-is-quix.md'


### PR DESCRIPTION
New page covers why 2.0, app.yaml inheritance, the written-vs-computed forms, before/after 1.0 vs 2.0, and migration on sync. Repoints the global-variables and project-variables inheritance notes at it as the canonical source.